### PR TITLE
Update clean function to specifically allow hyphens. Resolves #82.

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -26,6 +26,8 @@
 
 This application takes a CSV file and parses text records from another CSV file to detect and extract search term mentions using string similarity algorithms to account for common misspellings. It is named for the drug searching it does most commonly for us at IPOP but is flexible enough to accept any type search terms.
 
+> NOTE: In our text-preprocessing, we specifically *allow* hyphens ("-") to to their frequency in drug terminologies. If you want to see this functionality removed or put behind a feature flag, please file an Issue.
+
 If you are wondering about specific use cases, check out the [Examples](../examples/) folder!
 
 ## Requires

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -100,12 +100,11 @@ pub fn read_terms_from_file<P: AsRef<Path>>(p: P) -> Result<Vec<SearchTerm>> {
 ///
 /// let s = "This is a test-string with 1234 and some punctuation!@#$%^&*()";
 /// let cleaned = clean_text(s);
-/// assert_eq!(cleaned, "THIS IS A TEST STRING WITH 1234 AND SOME PUNCTUATION");
+/// assert_ne!(cleaned, "THIS IS A TEST STRING WITH 1234 AND SOME PUNCTUATION");
+/// assert_eq!(cleaned, "THIS IS A TEST-STRING WITH 1234 AND SOME PUNCTUATION");
 /// ```
 pub fn clean_text(s: &str) -> String {
-    // TODO: remove hyphenation and fix doc-test
-    s.replace(|c: char| !c.is_ascii_alphanumeric(), " ")
-    // s.replace(|c: char| !c.is_ascii_alphanumeric() && c != '-', " ")
+    s.replace(|c: char| !c.is_ascii_alphanumeric() && c != '-', " ")
         .trim()
         .to_ascii_uppercase()
 }
@@ -418,16 +417,34 @@ mod tests {
     #[test]
     fn test_clean_end_whitespace2() {
         let s = "!! This is a test to test- - hyphenated string.   ";
-        assert_eq!(clean_text(s), "this is a test to test    hyphenated string".to_ascii_uppercase());
+        assert_eq!(
+            clean_text(s),
+            "this is a test to test    hyphenated string".to_ascii_uppercase()
+        );
     }
 
     #[test]
     fn test_whitespace_split() {
         let s = "!! This is a test to test- - hyphenated string.   ";
-        assert_eq!(clean_text(s), "this is a test to test    hyphenated string".to_ascii_uppercase());
+        assert_eq!(
+            clean_text(s),
+            "this is a test to test    hyphenated string".to_ascii_uppercase()
+        );
         let c = clean_text(s);
         let v = c.split_ascii_whitespace().collect_vec();
-        assert_eq!(v, vec!["THIS", "IS", "A", "TEST", "TO", "TEST", "HYPHENATED", "STRING"]);
+        assert_eq!(
+            v,
+            vec![
+                "THIS",
+                "IS",
+                "A",
+                "TEST",
+                "TO",
+                "TEST",
+                "HYPHENATED",
+                "STRING"
+            ]
+        );
     }
 
     #[test]


### PR DESCRIPTION
Also updates doctest and adds a readme line mentioning this cleaning.